### PR TITLE
Reader: remove promisify & utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 .DS_Store
 *.json
+/debug.js

--- a/src/xml-reader/services/reader.js
+++ b/src/xml-reader/services/reader.js
@@ -1,11 +1,7 @@
 const xml2js = require('xml2js')
-const fs = require('fs')
-const util = require('util')
+const { readFileSync } = require('fs')
 const wordService = require('./words.js')
 
-// Promisify xml reader.
-const readFile = util.promisify(fs.readFile)
-xml2js.parseStringPromise = util.promisify(xml2js.parseString);
 
 /**
  * Get json from list of xml files
@@ -27,7 +23,7 @@ const readFiles = async (files) => {
  * Read content of individual file.
  */
 const getFileContent = async (filePath) => {
-  const content = await readFile(filePath)
+  const content = await readFileSync(filePath)
 
   return content
 }


### PR DESCRIPTION
Use method from xmllib & readFileSync instead. Fixes #6