### PR TITLE
XML to JSON settings: adjust merging & order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanakirju",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Karelian - Finnish dictionary. Scraped from hard-to-use data to easy-to-use data.",
   "repository": "https://github.com/stscoundrel/sanakirju.git",
   "author": "stscoundrel <sampo@pixels.fi>",

--- a/src/services/meanings.ts
+++ b/src/services/meanings.ts
@@ -28,7 +28,7 @@ export const getMeaning = (entry: RawEntry) : string => {
     }
 
     if (hasProperty(data.Definition[0], 'SeeAlso')) {
-      const type = data.Definition[0].SeeAlso[0].$.style;
+      const type = data.Definition[0].SeeAlso[0].style;
       const ref = data.Definition[0].SeeAlso[0].Ptr[0]._;
 
       return `${type} ${ref}`;

--- a/src/services/reader.ts
+++ b/src/services/reader.ts
@@ -16,7 +16,7 @@ const getFileContent = async (filePath: string) => {
  * Get words from file content.
  */
 const getWords = async (content: Buffer) : Promise<RawEntry[]> => {
-  const parser = new xml2js.Parser();
+  const parser = new xml2js.Parser({ mergeAttrs: true, preserveChildrenOrder: true });
 
   const data = await parser.parseStringPromise(content);
 

--- a/src/services/word-types.ts
+++ b/src/services/word-types.ts
@@ -13,7 +13,8 @@ export const getType = (entry: RawEntry): string[] => {
 
   if (hasProperty(data, 'PartOfSpeechCtn')) {
     if (Array.isArray(data.PartOfSpeechCtn)) {
-      return data.PartOfSpeechCtn.map((type) => type.PartOfSpeech[0].$.value);
+      const types = data.PartOfSpeechCtn.map((type) => type.PartOfSpeech[0].value);
+      return types.flat();
     }
   }
 

--- a/tests/integration/__snapshots__/dictionary-snapshots.test.ts.snap
+++ b/tests/integration/__snapshots__/dictionary-snapshots.test.ts.snap
@@ -1811,10 +1811,6 @@ Array [
 exports[`Dictionary content snapshot tests RawEntry data is as expected. 1`] = `
 Array [
   Object {
-    "$": Object {
-      "identifier": "a",
-      "sortKey": "1",
-    },
     "HeadwordCtn": Array [
       Object {
         "Headword": Array [
@@ -1827,9 +1823,6 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           "mutta.",
         ],
@@ -1848,17 +1841,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -1875,17 +1870,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -1904,17 +1901,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -1930,17 +1929,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -1956,17 +1957,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tihvinä",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -1980,18 +1983,22 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  ().  (). ",
@@ -1999,17 +2006,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2022,11 +2031,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -2034,17 +2045,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2060,17 +2073,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2080,39 +2095,45 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "konj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "konj.",
-                  "value": "conjunction",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "konj.",
+                ],
+                "value": Array [
+                  "conjunction",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           Object {
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "kielioppi",
-                  "kotus:grouping": "7",
-                },
                 "_": "kysymyslauseen",
+                "freeType": Array [
+                  "kielioppi",
+                ],
+                "kotus:grouping": Array [
+                  "7",
+                ],
               },
             ],
             "_": " kummastusta ilmaiseva interj. us.  alussa: kas, no, entäs. ",
@@ -2131,17 +2152,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2157,17 +2180,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2182,17 +2207,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2208,17 +2235,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2235,17 +2264,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2260,17 +2291,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2291,17 +2324,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2316,17 +2351,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2341,17 +2378,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2366,24 +2405,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2400,17 +2443,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2426,17 +2471,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2444,50 +2491,58 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "Erik.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "interj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "interj.",
-                  "value": "interjection",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "interj.",
+                ],
+                "value": Array [
+                  "interjection",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "3.",
-        },
         "Definition": Array [
           Object {
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "muunl. käyttöä",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
             "_": " . ",
@@ -2508,17 +2563,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2543,17 +2600,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2567,10 +2626,10 @@ Array [
                   Object {
                     "Ptr": Array [
                       Object {
-                        "$": Object {
-                          "xlink:href": "apa",
-                        },
                         "_": "→ apa.",
+                        "xlink:href": Array [
+                          "apa",
+                        ],
                       },
                     ],
                     "_": "apa, apo, apu  ",
@@ -2578,23 +2637,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
+                    "type": Array [
+                      "levikki",
+                    ],
                   },
                 ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "3.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "a",
+    ],
+    "sortKey": Array [
+      "1",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "aa",
-      "sortKey": "2",
-    },
     "HeadwordCtn": Array [
       Object {
         "Headword": Array [
@@ -2607,23 +2671,20 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ii",
-                    },
                     "_": "→ ii.",
+                    "xlink:href": Array [
+                      "ii",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -2632,30 +2693,34 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           "ahaa!",
         ],
@@ -2673,17 +2738,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2699,17 +2766,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2719,39 +2788,45 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "interj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "interj.",
-                  "value": "interjection",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "interj.",
+                ],
+                "value": Array [
+                  "interjection",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "3.",
-        },
         "Definition": Array [
           Object {
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "20",
-                },
                 "_": "tuutilaul.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "20",
+                ],
               },
             ],
             "_": " lasta nukutettaessa ja  ",
@@ -2770,17 +2845,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2796,17 +2873,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2827,17 +2906,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2845,60 +2926,71 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "Erik.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "interj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "interj.",
-                  "value": "interjection",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "interj.",
+                ],
+                "value": Array [
+                  "interjection",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "3.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "aa",
+    ],
+    "sortKey": Array [
+      "2",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "aakkoa",
-      "sortKey": "3",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "aa",
-                    },
                     "_": "»aa»",
+                    "xlink:href": Array [
+                      "aa",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -2919,17 +3011,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -2939,10 +3033,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -2952,11 +3046,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -2966,12 +3064,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "aakkoa",
+    ],
+    "sortKey": Array [
+      "3",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "aaloi",
-      "sortKey": "4",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -2988,17 +3088,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Pistoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3015,17 +3117,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3041,17 +3145,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3061,10 +3167,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3074,22 +3180,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -3099,12 +3213,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "aaloi",
+    ],
+    "sortKey": Array [
+      "4",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ah",
-      "sortKey": "5",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -3120,17 +3236,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3145,17 +3263,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3170,17 +3290,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3195,17 +3317,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3220,17 +3344,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3240,10 +3366,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "interj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3253,11 +3379,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "interj.",
-                  "value": "interjection",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "interj.",
+                ],
+                "value": Array [
+                  "interjection",
+                ],
               },
             ],
           },
@@ -3267,12 +3397,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ah",
+    ],
+    "sortKey": Array [
+      "5",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahah",
-      "sortKey": "6",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -3289,17 +3421,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3315,17 +3449,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3340,17 +3476,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3366,17 +3504,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3392,17 +3532,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3412,10 +3554,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "interj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3425,11 +3567,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "interj.",
-                  "value": "interjection",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "interj.",
+                ],
+                "value": Array [
+                  "interjection",
+                ],
               },
             ],
           },
@@ -3441,12 +3587,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahah",
+    ],
+    "sortKey": Array [
+      "6",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahahah",
-      "sortKey": "7",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -3465,17 +3613,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3485,10 +3635,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "interj.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3498,11 +3648,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "interj.",
-                  "value": "interjection",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "interj.",
+                ],
+                "value": Array [
+                  "interjection",
+                ],
               },
             ],
           },
@@ -3512,28 +3666,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahahah",
+    ],
+    "sortKey": Array [
+      "7",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahahella",
-      "sortKey": "8",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahah",
-                    },
                     "_": "»ahah»",
+                    "xlink:href": Array [
+                      "ahah",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -3554,17 +3710,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3580,17 +3738,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3600,10 +3760,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "frekv.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3613,19 +3773,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "frekv.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "frekv.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "frekv.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -3635,28 +3799,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahahella",
+    ],
+    "sortKey": Array [
+      "8",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahanta",
-      "sortKey": "9",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahtoa",
-                    },
                     "_": "→ ahtoa.",
+                    "xlink:href": Array [
+                      "ahtoa",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -3676,17 +3842,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3702,17 +3870,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3727,17 +3897,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3753,31 +3925,37 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3787,10 +3965,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3800,11 +3978,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -3814,20 +3996,22 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahanta",
+    ],
+    "sortKey": Array [
+      "9",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahas",
-      "sortKey": "10",
-    },
     "HeadwordCtn": Array [
       Object {
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -3837,11 +4021,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -3853,9 +4041,6 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           "ahdas.",
         ],
@@ -3873,38 +4058,46 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Hietaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3920,17 +4113,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3946,17 +4141,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3973,17 +4170,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -3999,17 +4198,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Mäntys",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4025,17 +4226,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4050,17 +4253,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4076,17 +4281,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tihvinä",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4102,17 +4309,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Valdai",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4125,11 +4334,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sp.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -4137,17 +4348,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4161,11 +4374,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). . ",
@@ -4173,17 +4388,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4199,24 +4416,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vielj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4233,17 +4454,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4259,17 +4482,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4277,11 +4502,11 @@ Array [
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           "vaikea, tukala.",
         ],
@@ -4299,17 +4524,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4326,17 +4553,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tihvinä",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4352,17 +4581,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4370,14 +4601,19 @@ Array [
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "ahas",
+    ],
+    "sortKey": Array [
+      "10",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahashenkine",
-      "sortKey": "11",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -4397,17 +4633,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4423,17 +4661,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4443,38 +4683,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahashenkine",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahas/henkine",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -4484,12 +4730,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahashenkine",
+    ],
+    "sortKey": Array [
+      "11",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahasläntä",
-      "sortKey": "12",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -4509,17 +4757,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4535,17 +4785,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4555,10 +4807,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "mod.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -4568,19 +4820,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "mod.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "mod.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mod.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -4590,12 +4846,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahasläntä",
+    ],
+    "sortKey": Array [
+      "12",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahava",
-      "sortKey": "13",
-    },
     "HeadwordCtn": Array [
       Object {
         "Headword": Array [
@@ -4608,9 +4866,6 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           "kuiva, voimakas ja kylmä, pureva (kevät)tuuli t. (-)ilma.",
         ],
@@ -4628,17 +4883,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4654,38 +4911,46 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Pistoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Poraj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4701,45 +4966,55 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kontokki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tunkua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4755,17 +5030,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4781,17 +5058,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4807,17 +5086,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4833,17 +5114,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Valdai",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4856,11 +5139,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sp.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (turvattoman huokaus; ). ",
@@ -4868,17 +5153,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4894,17 +5181,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4920,24 +5209,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4953,17 +5246,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tulemaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -4978,17 +5273,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5004,17 +5301,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5034,9 +5333,9 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
+                    "type": Array [
+                      "levikki",
+                    ],
                   },
                 ],
               },
@@ -5051,17 +5350,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5077,17 +5378,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5103,17 +5406,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5129,17 +5434,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5155,17 +5462,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5173,41 +5482,47 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "Erik.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           "ahavainen, kylmätuulinen.",
         ],
@@ -5225,17 +5540,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tunkua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5251,17 +5568,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5278,17 +5597,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5305,17 +5626,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Valdai",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5331,17 +5654,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5361,17 +5686,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5387,24 +5714,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5412,60 +5743,71 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "kielioppi",
-                  "kotus:grouping": "3",
-                },
                 "_": "Adv:sesti.",
+                "freeType": Array [
+                  "kielioppi",
+                ],
+                "kotus:grouping": Array [
+                  "3",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "ahava",
+    ],
+    "sortKey": Array [
+      "13",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavahko",
-      "sortKey": "14",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahava",
-                    },
                     "_": "→ ahava.",
+                    "xlink:href": Array [
+                      "ahava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -5485,17 +5827,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5511,17 +5855,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5531,10 +5877,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "mod.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -5544,19 +5890,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "mod.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "mod.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mod.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -5566,13 +5916,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavahko",
+    ],
+    "sortKey": Array [
+      "14",
+    ],
   },
   Object {
-    "$": Object {
-      "homographNumber": "I",
-      "identifier": "ahavaine01",
-      "sortKey": "15",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -5592,17 +5943,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5612,10 +5965,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -5625,11 +5978,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -5639,29 +5996,33 @@ Array [
         ],
       },
     ],
+    "homographNumber": Array [
+      "I",
+    ],
+    "identifier": Array [
+      "ahavaine01",
+    ],
+    "sortKey": Array [
+      "15",
+    ],
   },
   Object {
-    "$": Object {
-      "homographNumber": "II",
-      "identifier": "ahavaine02",
-      "sortKey": "16",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahava",
-                    },
                     "_": "→ ahava.",
+                    "xlink:href": Array [
+                      "ahava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -5681,17 +6042,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5701,10 +6064,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "dem.s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -5714,19 +6077,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "dem.s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "dem.s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "dem.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -5736,12 +6103,17 @@ Array [
         ],
       },
     ],
+    "homographNumber": Array [
+      "II",
+    ],
+    "identifier": Array [
+      "ahavaine02",
+    ],
+    "sortKey": Array [
+      "16",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavakala",
-      "sortKey": "17",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -5758,17 +6130,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Poraj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5785,17 +6159,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Ilom",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5805,38 +6181,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahavakala",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahava/kala",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -5846,28 +6228,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavakala",
+    ],
+    "sortKey": Array [
+      "17",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavakas",
-      "sortKey": "18",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahava",
-                    },
                     "_": "= ahava 2.",
+                    "xlink:href": Array [
+                      "ahava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -5887,17 +6271,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5913,17 +6299,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -5933,10 +6321,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -5946,11 +6334,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -5960,28 +6352,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavakas",
+    ],
+    "sortKey": Array [
+      "18",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavakkaine",
-      "sortKey": "19",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavahko",
-                    },
                     "_": "= ahavahko.",
+                    "xlink:href": Array [
+                      "ahavahko",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -6001,17 +6395,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6027,17 +6423,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6047,10 +6445,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "mod.s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -6060,30 +6458,38 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "mod.s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "mod.s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mod.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -6093,28 +6499,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavakkaine",
+    ],
+    "sortKey": Array [
+      "19",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavakkali",
-      "sortKey": "20",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahava",
-                    },
                     "_": "→ ahava.",
+                    "xlink:href": Array [
+                      "ahava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -6134,17 +6542,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6160,17 +6570,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6180,10 +6592,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "adv.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -6193,11 +6605,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "adv.",
-                  "value": "adverb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "adv.",
+                ],
+                "value": Array [
+                  "adverb",
+                ],
               },
             ],
           },
@@ -6207,12 +6623,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavakkali",
+    ],
+    "sortKey": Array [
+      "20",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavakoittuo",
-      "sortKey": "21",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -6232,17 +6650,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6252,10 +6672,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -6265,11 +6685,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -6279,12 +6703,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavakoittuo",
+    ],
+    "sortKey": Array [
+      "21",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavaliha",
-      "sortKey": "22",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -6301,17 +6727,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Poraj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6327,17 +6755,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Ilom",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6353,17 +6783,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6379,17 +6811,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6405,17 +6839,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6425,38 +6861,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahavaliha",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahava/liha",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -6466,12 +6908,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavaliha",
+    ],
+    "sortKey": Array [
+      "22",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavapäivä",
-      "sortKey": "23",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -6491,17 +6935,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6514,11 +6960,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "12",
-                        },
                         "_": "itkuv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "12",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -6526,17 +6974,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6546,38 +6996,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahavapäivä",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahava/päivä",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -6587,12 +7043,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavapäivä",
+    ],
+    "sortKey": Array [
+      "23",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavas",
-      "sortKey": "24",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -6609,17 +7067,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6629,10 +7089,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -6642,11 +7102,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -6656,12 +7120,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavas",
+    ],
+    "sortKey": Array [
+      "24",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavaseä",
-      "sortKey": "25",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -6681,17 +7147,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6707,17 +7175,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6727,38 +7197,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahavaseä",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahava/seä",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -6768,12 +7244,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavaseä",
+    ],
+    "sortKey": Array [
+      "25",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavastuo",
-      "sortKey": "26",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -6793,17 +7271,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6819,17 +7299,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Pistoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6839,10 +7321,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -6852,11 +7334,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -6866,28 +7352,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavastuo",
+    ],
+    "sortKey": Array [
+      "26",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavattava",
-      "sortKey": "27",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahava",
-                    },
                     "_": "→ ahava 2.",
+                    "xlink:href": Array [
+                      "ahava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -6907,17 +7395,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6933,17 +7423,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6959,17 +7451,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -6979,10 +7473,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "mod.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -6992,19 +7486,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "mod.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "mod.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mod.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -7014,28 +7512,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavattava",
+    ],
+    "sortKey": Array [
+      "27",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavattšaine",
-      "sortKey": "28",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavattava",
-                    },
                     "_": "= ahavattava.",
+                    "xlink:href": Array [
+                      "ahavattava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -7055,17 +7555,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7081,17 +7583,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7101,10 +7605,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "mod.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -7114,19 +7618,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "mod.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "mod.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mod.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -7137,12 +7645,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavattšaine",
+    ],
+    "sortKey": Array [
+      "28",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavatuuli",
-      "sortKey": "29",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -7162,17 +7672,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7182,38 +7694,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahavatuuli",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahava/tuuli",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -7223,28 +7741,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavatuuli",
+    ],
+    "sortKey": Array [
+      "29",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavo",
-      "sortKey": "30",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahava",
-                    },
                     "_": "→ ahava.",
+                    "xlink:href": Array [
+                      "ahava",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -7252,10 +7772,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -7265,11 +7785,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -7279,20 +7803,22 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavo",
+    ],
+    "sortKey": Array [
+      "30",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoija",
-      "sortKey": "31",
-    },
     "HeadwordCtn": Array [
       Object {
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -7302,11 +7828,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -7318,9 +7848,6 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           "tuulla purevasti, tuntua kylmältä.",
         ],
@@ -7338,17 +7865,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7364,17 +7893,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7387,11 +7918,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -7399,17 +7932,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7425,17 +7960,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7448,11 +7985,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "12",
-                        },
                         "_": "itkuv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "12",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -7460,17 +7999,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7480,56 +8021,62 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "intr.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "intr.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "intr.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "intr.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           Object {
             "PartOfSpeechCtn": Array [
               Object {
                 "PartOfSpeech": Array [
                   Object {
-                    "$": Object {
-                      "display": "yes",
-                      "freeValue": "intr.",
-                    },
+                    "display": Array [
+                      "yes",
+                    ],
+                    "freeValue": Array [
+                      "intr.",
+                    ],
                   },
                 ],
                 "Subcategorisation": Array [
                   Object {
-                    "$": Object {
-                      "display": "no",
-                    },
                     "_": "intr.",
+                    "display": Array [
+                      "no",
+                    ],
                   },
                 ],
               },
@@ -7551,17 +8098,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7577,31 +8126,37 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tunkua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7617,17 +8172,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7643,17 +8200,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7669,17 +8228,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7695,17 +8256,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7721,17 +8284,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7747,17 +8312,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7773,17 +8340,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tulemaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7802,17 +8371,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7828,17 +8399,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7854,17 +8427,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7874,38 +8449,42 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "tr.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "tr.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "tr.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "tr.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "3.",
-        },
         "Definition": Array [
           "sierettää (iho, kasvot).",
         ],
@@ -7923,17 +8502,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7948,17 +8529,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tunkua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -7974,17 +8557,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8000,17 +8585,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8026,17 +8613,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8053,17 +8642,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8079,17 +8670,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8097,11 +8690,11 @@ Array [
             ],
           },
         ],
+        "senseNumber": Array [
+          "3.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "4.",
-        },
         "Definition": Array [
           "huikaista, häikäistä (silmät).",
         ],
@@ -8119,17 +8712,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8145,17 +8740,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8163,30 +8760,35 @@ Array [
             ],
           },
         ],
+        "senseNumber": Array [
+          "4.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "ahavoija",
+    ],
+    "sortKey": Array [
+      "31",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoijakseh",
-      "sortKey": "32",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavoija",
-                    },
                     "_": "→ ahavoija.",
+                    "xlink:href": Array [
+                      "ahavoija",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -8206,17 +8808,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8226,10 +8830,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "refl.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -8239,19 +8843,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "refl.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "refl.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "refl.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -8261,28 +8869,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoijakseh",
+    ],
+    "sortKey": Array [
+      "32",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoikas",
-      "sortKey": "33",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavakas",
-                    },
                     "_": "= ahavakas.",
+                    "xlink:href": Array [
+                      "ahavakas",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -8302,17 +8912,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8322,10 +8934,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "poss.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -8335,11 +8947,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "poss.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "poss.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -8349,28 +8965,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoikas",
+    ],
+    "sortKey": Array [
+      "33",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavointa",
-      "sortKey": "34",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavoija",
-                    },
                     "_": "→ ahavoija.",
+                    "xlink:href": Array [
+                      "ahavoija",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -8390,17 +9008,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8410,10 +9030,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -8423,11 +9043,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -8437,12 +9061,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavointa",
+    ],
+    "sortKey": Array [
+      "34",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoitšiettšie",
-      "sortKey": "35",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -8462,17 +9088,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8482,10 +9110,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "refl.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -8495,19 +9123,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "refl.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "refl.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "refl.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -8518,28 +9150,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoitšiettšie",
+    ],
+    "sortKey": Array [
+      "35",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoitšusliha",
-      "sortKey": "36",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavaliha",
-                    },
                     "_": "= ahavaliha.",
+                    "xlink:href": Array [
+                      "ahavaliha",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -8559,17 +9193,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8585,17 +9221,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8605,38 +9243,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahavoitšusliha",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahavoitšus/liha",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -8647,28 +9291,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoitšusliha",
+    ],
+    "sortKey": Array [
+      "36",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoitšuttoa",
-      "sortKey": "37",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavoittšuo",
-                    },
                     "_": "→ ahavoittšuo.",
+                    "xlink:href": Array [
+                      "ahavoittšuo",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -8688,17 +9334,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8714,17 +9362,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8740,17 +9390,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8760,10 +9412,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "kaus.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -8773,19 +9425,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "kaus.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "kaus.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "kaus.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -8796,12 +9452,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoitšuttoa",
+    ],
+    "sortKey": Array [
+      "37",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoittoa",
-      "sortKey": "38",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -8815,11 +9473,13 @@ Array [
                     ],
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "lähde",
-                          "freeType": "lähde",
-                        },
                         "_": "(SKVR I 1245 c)",
+                        "class": Array [
+                          "lähde",
+                        ],
+                        "freeType": Array [
+                          "lähde",
+                        ],
                         "sub": Array [
                           "4",
                         ],
@@ -8830,17 +9490,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8856,17 +9518,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8882,17 +9546,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8902,10 +9568,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -8915,11 +9581,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -8929,12 +9599,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoittoa",
+    ],
+    "sortKey": Array [
+      "38",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoittšiutuo",
-      "sortKey": "39",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -8954,17 +9626,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -8980,17 +9654,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9000,10 +9676,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "pass.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9013,19 +9689,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "pass.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "pass.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "pass.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -9036,28 +9716,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoittšiutuo",
+    ],
+    "sortKey": Array [
+      "39",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoittšuo",
-      "sortKey": "40",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavoittšiutuo",
-                    },
                     "_": "= ahavoittšiutuo.",
+                    "xlink:href": Array [
+                      "ahavoittšiutuo",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -9077,17 +9759,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9103,17 +9787,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9123,10 +9809,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "pass.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9136,19 +9822,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "pass.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "pass.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "pass.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -9159,12 +9849,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoittšuo",
+    ],
+    "sortKey": Array [
+      "40",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoittuo",
-      "sortKey": "41",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -9184,17 +9876,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Ilom",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9210,17 +9904,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9236,17 +9932,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9256,10 +9954,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9269,11 +9967,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -9283,28 +9985,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoittuo",
+    ],
+    "sortKey": Array [
+      "41",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahavoituo",
-      "sortKey": "42",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahavoittuo",
-                    },
                     "_": "= ahavoittuo.",
+                    "xlink:href": Array [
+                      "ahavoittuo",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -9324,17 +10028,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9350,17 +10056,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9376,17 +10084,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9396,10 +10106,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9409,11 +10119,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -9423,12 +10137,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahavoituo",
+    ],
+    "sortKey": Array [
+      "42",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahe",
-      "sortKey": "43",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -9450,17 +10166,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kontokki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9470,10 +10188,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9483,11 +10201,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -9497,12 +10219,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahe",
+    ],
+    "sortKey": Array [
+      "43",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahelmus",
-      "sortKey": "44",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -9522,17 +10246,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9548,17 +10274,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9568,10 +10296,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9581,11 +10309,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -9595,12 +10327,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahelmus",
+    ],
+    "sortKey": Array [
+      "44",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahertoa",
-      "sortKey": "45",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -9620,17 +10354,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9640,10 +10376,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9653,11 +10389,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -9667,12 +10407,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahertoa",
+    ],
+    "sortKey": Array [
+      "45",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahetellakseh",
-      "sortKey": "46",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -9692,17 +10434,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9712,10 +10456,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "frekv.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9725,19 +10469,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "frekv.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "frekv.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "frekv.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -9747,12 +10495,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahetellakseh",
+    ],
+    "sortKey": Array [
+      "46",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinko",
-      "sortKey": "47",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -9772,24 +10522,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9805,17 +10559,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9831,17 +10587,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9857,17 +10615,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9882,17 +10642,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9902,10 +10664,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -9915,11 +10677,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -9929,12 +10695,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinko",
+    ],
+    "sortKey": Array [
+      "47",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinkovesi",
-      "sortKey": "48",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -9952,17 +10720,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -9972,38 +10742,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahinkovesi",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahinko/vesi",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -10013,12 +10789,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinkovesi",
+    ],
+    "sortKey": Array [
+      "48",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinlauta",
-      "sortKey": "49",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -10037,26 +10815,25 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                     ],
                     "_": " , ",
+                    "type": Array [
+                      "levikki",
+                    ],
                   },
                 ],
               },
               Object {
-                "$": Object {
-                  "class": "pilkku",
-                },
                 "Example": Array [
                   Object {
                     "Fragment": Array [
@@ -10066,54 +10843,64 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tunkua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                     ],
                     "_": "     , ",
+                    "type": Array [
+                      "levikki",
+                    ],
                   },
+                ],
+                "class": Array [
+                  "pilkku",
                 ],
               },
               Object {
-                "$": Object {
-                  "class": "pilkku",
-                },
                 "Example": Array [
                   Object {
                     "Fragment": Array [
@@ -10123,61 +10910,78 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tulemaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vielj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                     ],
+                    "type": Array [
+                      "levikki",
+                    ],
                   },
+                ],
+                "class": Array [
+                  "pilkku",
                 ],
               },
               Object {
@@ -10191,17 +10995,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10217,17 +11023,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10240,11 +11048,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "10",
-                        },
                         "_": "hoku",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "10",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -10252,17 +11062,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10278,17 +11090,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10303,17 +11117,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10329,17 +11145,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10349,38 +11167,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahinlauta",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahin/lauta",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -10390,12 +11214,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinlauta",
+    ],
+    "sortKey": Array [
+      "49",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinlautaparsi",
-      "sortKey": "50",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -10415,17 +11241,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10441,17 +11269,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10467,17 +11297,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10487,38 +11319,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahinlautaparsi",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahin/lauta/parsi",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -10528,12 +11366,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinlautaparsi",
+    ],
+    "sortKey": Array [
+      "50",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinparsi",
-      "sortKey": "51",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -10550,17 +11390,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10570,65 +11412,75 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "kielioppi",
-                  "kotus:grouping": "5",
-                },
                 "_": "tav. mon.",
+                "freeType": Array [
+                  "kielioppi",
+                ],
+                "kotus:grouping": Array [
+                  "5",
+                ],
               },
             ],
             "_": "s., ",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahinparsi",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahin/parsi",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "tav. mon.",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "tav. mon.",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mon.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -10638,12 +11490,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinparsi",
+    ],
+    "sortKey": Array [
+      "51",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinpartiaine",
-      "sortKey": "52",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -10663,17 +11517,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10683,65 +11539,75 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "kielioppi",
-                  "kotus:grouping": "5",
-                },
                 "_": "tav. mon.",
+                "freeType": Array [
+                  "kielioppi",
+                ],
+                "kotus:grouping": Array [
+                  "5",
+                ],
               },
             ],
             "_": "s., ",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahinpartiaine",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahin/partiaine",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "tav. mon.",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "tav. mon.",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mon.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -10751,28 +11617,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinpartiaine",
+    ],
+    "sortKey": Array [
+      "52",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahinpartine",
-      "sortKey": "53",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahinpartiaine",
-                    },
                     "_": "= ahinpartiaine.",
+                    "xlink:href": Array [
+                      "ahinpartiaine",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -10793,17 +11661,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10819,17 +11689,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10845,17 +11717,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10865,38 +11739,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahinpartine",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahin/partine",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -10906,28 +11786,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahinpartine",
+    ],
+    "sortKey": Array [
+      "53",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahislauta",
-      "sortKey": "54",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahinlauta",
-                    },
                     "_": "= ahinlauta.",
+                    "xlink:href": Array [
+                      "ahinlauta",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -10947,17 +11829,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Ilom",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10973,17 +11857,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -10993,38 +11879,44 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
           Object {
-            "$": Object {
-              "type": "compound",
-            },
             "_": "ahislauta",
+            "type": Array [
+              "compound",
+            ],
           },
         ],
         "Hyphenation": Array [
           Object {
-            "$": Object {
-              "display": "no",
-              "freeType": "yhdyssanarajat",
-            },
             "_": "ahis/lauta",
+            "display": Array [
+              "no",
+            ],
+            "freeType": Array [
+              "yhdyssanarajat",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -11034,12 +11926,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahislauta",
+    ],
+    "sortKey": Array [
+      "54",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahissella",
-      "sortKey": "55",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11059,17 +11953,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11085,17 +11981,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11112,17 +12010,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11138,17 +12038,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11164,17 +12066,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11184,10 +12088,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11197,11 +12101,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -11211,28 +12119,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahissella",
+    ],
+    "sortKey": Array [
+      "55",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahissellakseh",
-      "sortKey": "56",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahissella",
-                    },
                     "_": "→ ahissella.",
+                    "xlink:href": Array [
+                      "ahissella",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -11253,17 +12163,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11273,10 +12185,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "refl.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11286,19 +12198,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "refl.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "refl.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "refl.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -11308,12 +12224,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahissellakseh",
+    ],
+    "sortKey": Array [
+      "56",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahisselmus",
-      "sortKey": "57",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11331,11 +12249,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                     ],
                     "_": "  (hevonen),  (). ",
@@ -11343,17 +12263,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11366,11 +12288,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                     ],
                     "_": "  ahdinkoon (). ",
@@ -11378,17 +12302,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11398,10 +12324,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11411,11 +12337,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -11425,12 +12355,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahisselmus",
+    ],
+    "sortKey": Array [
+      "57",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahissus",
-      "sortKey": "58",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11450,31 +12382,37 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11490,17 +12428,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11516,17 +12456,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11542,17 +12484,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11562,10 +12506,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11575,11 +12519,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -11589,12 +12537,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahissus",
+    ],
+    "sortKey": Array [
+      "58",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahistaja",
-      "sortKey": "59",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11614,17 +12564,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11640,17 +12592,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11660,10 +12614,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11673,11 +12627,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -11687,12 +12645,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahistaja",
+    ],
+    "sortKey": Array [
+      "59",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahistautuo",
-      "sortKey": "60",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11712,17 +12672,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11732,10 +12694,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "refl.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11745,19 +12707,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "refl.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "refl.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "refl.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -11767,12 +12733,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahistautuo",
+    ],
+    "sortKey": Array [
+      "60",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahistelenta",
-      "sortKey": "61",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11792,17 +12760,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11812,10 +12782,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -11825,11 +12795,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -11839,12 +12813,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahistelenta",
+    ],
+    "sortKey": Array [
+      "61",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahistoa",
-      "sortKey": "62",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -11864,17 +12840,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11890,17 +12868,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11915,17 +12895,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11941,24 +12923,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -11975,17 +12961,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12001,24 +12989,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12035,17 +13027,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12059,18 +13053,22 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  ().  (). ",
@@ -12078,17 +13076,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12104,17 +13104,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12130,17 +13132,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12156,17 +13160,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12182,17 +13188,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12202,10 +13210,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -12215,11 +13223,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -12229,28 +13241,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahistoa",
+    ],
+    "sortKey": Array [
+      "62",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahistuo",
-      "sortKey": "63",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahas",
-                    },
                     "_": "→ ahas.",
+                    "xlink:href": Array [
+                      "ahas",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -12271,17 +13285,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12297,17 +13313,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12323,17 +13341,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12343,10 +13363,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -12356,11 +13376,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -12370,12 +13394,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahistuo",
+    ],
+    "sortKey": Array [
+      "63",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahjelmus",
-      "sortKey": "64",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -12392,11 +13418,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -12404,17 +13432,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12434,17 +13464,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12452,21 +13484,23 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "18",
-                },
                 "_": "Kuv.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "18",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -12476,11 +13510,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -12490,20 +13528,22 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahjelmus",
+    ],
+    "sortKey": Array [
+      "64",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahjo",
-      "sortKey": "65",
-    },
     "HeadwordCtn": Array [
       Object {
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -12513,11 +13553,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -12529,9 +13573,6 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           "pajan tulisija.",
         ],
@@ -12549,80 +13590,100 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tulemaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vielj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12638,17 +13699,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12663,17 +13726,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Salmi",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12689,17 +13754,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12714,17 +13781,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12740,17 +13809,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12758,11 +13829,11 @@ Array [
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           "hiillos.",
         ],
@@ -12780,17 +13851,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12806,17 +13879,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12832,17 +13907,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12859,17 +13936,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12889,17 +13968,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12907,23 +13988,30 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "Erik.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "ahjo",
+    ],
+    "sortKey": Array [
+      "65",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahjolline",
-      "sortKey": "66",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -12943,17 +14031,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12969,17 +14059,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -12989,10 +14081,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13002,11 +14094,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -13016,12 +14112,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahjolline",
+    ],
+    "sortKey": Array [
+      "66",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahjos",
-      "sortKey": "67",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -13038,17 +14136,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13064,17 +14164,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13084,10 +14186,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13097,11 +14199,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -13111,28 +14217,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahjos",
+    ],
+    "sortKey": Array [
+      "67",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahjostoa",
-      "sortKey": "68",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "aihostoa",
-                    },
                     "_": "= aihostoa.",
+                    "xlink:href": Array [
+                      "aihostoa",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -13152,17 +14260,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tver",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13172,10 +14282,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13185,11 +14295,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -13199,12 +14313,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahjostoa",
+    ],
+    "sortKey": Array [
+      "68",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahjota",
-      "sortKey": "69",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -13224,17 +14340,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13244,10 +14362,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13257,11 +14375,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -13271,28 +14393,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahjota",
+    ],
+    "sortKey": Array [
+      "69",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkahellakseh",
-      "sortKey": "70",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkahtoakseh",
-                    },
                     "_": "→ ahkahtoakseh.",
+                    "xlink:href": Array [
+                      "ahkahtoakseh",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -13312,17 +14436,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13332,10 +14458,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "frekv.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13345,19 +14471,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "frekv.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "frekv.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "frekv.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -13367,28 +14497,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkahellakseh",
+    ],
+    "sortKey": Array [
+      "70",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkahtoakseh",
-      "sortKey": "71",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ah",
-                    },
                     "_": "»ah»",
+                    "xlink:href": Array [
+                      "ah",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -13409,17 +14541,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13434,17 +14568,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13454,10 +14590,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "refl.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13467,19 +14603,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "refl.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "refl.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "refl.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -13489,28 +14629,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkahtoakseh",
+    ],
+    "sortKey": Array [
+      "71",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkahus",
-      "sortKey": "72",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkahtoakseh",
-                    },
                     "_": "→ ahkahtoakseh.",
+                    "xlink:href": Array [
+                      "ahkahtoakseh",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -13527,11 +14669,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -13539,17 +14683,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13562,11 +14708,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -13574,17 +14722,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13594,10 +14744,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13607,11 +14757,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -13621,28 +14775,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkahus",
+    ],
+    "sortKey": Array [
+      "72",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkahuttoa",
-      "sortKey": "73",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkahtoakseh",
-                    },
                     "_": "→ ahkahtoakseh.",
+                    "xlink:href": Array [
+                      "ahkahtoakseh",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -13662,17 +14818,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13682,10 +14840,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "kaus.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13695,19 +14853,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "kaus.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "kaus.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "kaus.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -13717,28 +14879,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkahuttoa",
+    ],
+    "sortKey": Array [
+      "73",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkaillakseh",
-      "sortKey": "74",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ah",
-                    },
                     "_": "»ah»",
+                    "xlink:href": Array [
+                      "ah",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -13757,10 +14921,10 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "kielioppi",
-                        },
                         "_": "inf.",
+                        "freeType": Array [
+                          "kielioppi",
+                        ],
                       },
                     ],
                     "_": "   . ",
@@ -13768,17 +14932,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13793,17 +14959,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13813,10 +14981,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "refl.v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13826,19 +14994,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "refl.v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "refl.v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "refl.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -13848,28 +15020,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkaillakseh",
+    ],
+    "sortKey": Array [
+      "74",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkajus",
-      "sortKey": "75",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkahus",
-                    },
                     "_": "= ahkahus.",
+                    "xlink:href": Array [
+                      "ahkahus",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -13886,11 +15060,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -13898,17 +15074,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -13918,10 +15096,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -13931,11 +15109,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -13945,28 +15127,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkajus",
+    ],
+    "sortKey": Array [
+      "75",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkavus",
-      "sortKey": "76",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkajus",
-                    },
                     "_": "= ahkajus.",
+                    "xlink:href": Array [
+                      "ahkajus",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -13983,11 +15167,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "29",
-                        },
                         "_": "sl.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "29",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -13995,17 +15181,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14015,10 +15203,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -14028,11 +15216,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -14042,12 +15234,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkavus",
+    ],
+    "sortKey": Array [
+      "76",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkera",
-      "sortKey": "77",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -14067,17 +15261,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14093,17 +15289,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14116,11 +15314,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "38",
-                        },
                         "_": "uud.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "38",
+                        ],
                       },
                     ],
                     "_": "  (). ",
@@ -14128,17 +15328,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14148,10 +15350,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -14161,11 +15363,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -14175,28 +15381,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkera",
+    ],
+    "sortKey": Array [
+      "77",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkeraine",
-      "sortKey": "78",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkera",
-                    },
                     "_": "→ ahkera.",
+                    "xlink:href": Array [
+                      "ahkera",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -14216,17 +15424,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14246,17 +15456,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14264,21 +15476,23 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "kielioppi",
-                  "kotus:grouping": "3",
-                },
                 "_": "Adv:sesti.",
+                "freeType": Array [
+                  "kielioppi",
+                ],
+                "kotus:grouping": Array [
+                  "3",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "dem.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -14288,19 +15502,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "dem.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "dem.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "dem.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -14310,12 +15528,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkeraine",
+    ],
+    "sortKey": Array [
+      "78",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkeroija",
-      "sortKey": "79",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -14335,24 +15555,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14362,10 +15586,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -14375,11 +15599,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -14389,28 +15617,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkeroija",
+    ],
+    "sortKey": Array [
+      "79",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkertoa",
-      "sortKey": "80",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahertoa",
-                    },
                     "_": "= ahertoa.",
+                    "xlink:href": Array [
+                      "ahertoa",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -14430,17 +15660,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14450,10 +15682,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -14463,11 +15695,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -14477,28 +15713,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkertoa",
+    ],
+    "sortKey": Array [
+      "80",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkerus",
-      "sortKey": "81",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkera",
-                    },
                     "_": "→ ahkera.",
+                    "xlink:href": Array [
+                      "ahkera",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -14518,17 +15756,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14542,11 +15782,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "38",
-                        },
                         "_": "uud.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "38",
+                        ],
                       },
                     ],
                     "_": "  yhtä ahkerasti  (). ",
@@ -14554,17 +15796,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14574,10 +15818,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -14587,22 +15831,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -14612,12 +15864,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkerus",
+    ],
+    "sortKey": Array [
+      "81",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkivo",
-      "sortKey": "82",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -14637,17 +15891,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Oulanka",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14664,17 +15920,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14690,17 +15948,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Pistoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14716,17 +15976,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14742,17 +16004,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14768,17 +16032,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14794,17 +16060,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Paatene",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14820,17 +16088,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14846,24 +16116,28 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14879,17 +16153,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14909,17 +16185,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14935,17 +16213,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Impil",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14953,11 +16233,13 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "18",
-                },
                 "_": "Kuv.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "18",
+                ],
               },
             ],
           },
@@ -14974,17 +16256,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Pistoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -14992,21 +16276,23 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "Erik.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
           },
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15016,11 +16302,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -15030,12 +16320,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkivo",
+    ],
+    "sortKey": Array [
+      "82",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkivolline",
-      "sortKey": "83",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -15055,17 +16347,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15075,10 +16369,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15088,11 +16382,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -15102,28 +16400,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkivolline",
+    ],
+    "sortKey": Array [
+      "83",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkoa",
-      "sortKey": "84",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "synonyymi",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ah",
-                    },
                     "_": "»ah»",
+                    "xlink:href": Array [
+                      "ah",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "synonyymi",
                 ],
               },
             ],
@@ -15144,17 +16444,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15164,10 +16466,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15177,11 +16479,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -15191,28 +16497,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkoa",
+    ],
+    "sortKey": Array [
+      "84",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkoallakseh",
-      "sortKey": "85",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkaillakseh",
-                    },
                     "_": "→ ahkaillakseh.",
+                    "xlink:href": Array [
+                      "ahkaillakseh",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -15220,10 +16528,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15233,11 +16541,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -15247,28 +16559,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkoallakseh",
+    ],
+    "sortKey": Array [
+      "85",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkoallattši",
-      "sortKey": "86",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahkaillakseh",
-                    },
                     "_": "→ ahkaillakseh.",
+                    "xlink:href": Array [
+                      "ahkaillakseh",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -15276,10 +16590,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15289,11 +16603,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -15304,20 +16622,22 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkoallattši",
+    ],
+    "sortKey": Array [
+      "86",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahku",
-      "sortKey": "87",
-    },
     "HeadwordCtn": Array [
       Object {
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15327,11 +16647,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -15343,9 +16667,6 @@ Array [
     ],
     "SenseGrp": Array [
       Object {
-        "$": Object {
-          "senseNumber": "1.",
-        },
         "Definition": Array [
           "sakka, kuona, jätteet.",
         ],
@@ -15364,17 +16685,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15390,17 +16713,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15416,17 +16741,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15442,17 +16769,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Jyskyj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15469,17 +16798,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15495,17 +16826,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suistamo",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15521,17 +16854,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15539,11 +16874,11 @@ Array [
             ],
           },
         ],
+        "senseNumber": Array [
+          "1.",
+        ],
       },
       Object {
-        "$": Object {
-          "senseNumber": "2.",
-        },
         "Definition": Array [
           "aivot.",
         ],
@@ -15561,17 +16896,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15591,17 +16928,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Nek-Riip",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15609,11 +16948,13 @@ Array [
             ],
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "käyttöala",
-                  "kotus:grouping": "6",
-                },
                 "_": "Erik.",
+                "freeType": Array [
+                  "käyttöala",
+                ],
+                "kotus:grouping": Array [
+                  "6",
+                ],
               },
             ],
           },
@@ -15624,19 +16965,21 @@ Array [
                   Object {
                     "SeeAlso": Array [
                       Object {
-                        "$": Object {
-                          "class": "Vrt",
-                          "style": "muu",
-                        },
                         "Ptr": Array [
                           Object {
-                            "$": Object {
-                              "xlink:href": "apara",
-                            },
                             "_": "apara",
+                            "xlink:href": Array [
+                              "apara",
+                            ],
                           },
                         ],
                         "_": "Vrt. .",
+                        "class": Array [
+                          "Vrt",
+                        ],
+                        "style": Array [
+                          "muu",
+                        ],
                       },
                     ],
                   },
@@ -15647,50 +16990,61 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "RangeOfApplication": Array [
               Object {
-                "$": Object {
-                  "freeType": "kielioppi",
-                  "kotus:grouping": "5",
-                },
                 "_": "mon.",
+                "freeType": Array [
+                  "kielioppi",
+                ],
+                "kotus:grouping": Array [
+                  "5",
+                ],
               },
             ],
             "_": "s. ",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "PartOfSpeechCtn": Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s. mon.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s. mon.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "mon.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
         ],
+        "senseNumber": Array [
+          "2.",
+        ],
       },
+    ],
+    "identifier": Array [
+      "ahku",
+    ],
+    "sortKey": Array [
+      "87",
     ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkuhine",
-      "sortKey": "88",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -15710,17 +17064,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15730,10 +17086,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15743,11 +17099,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -15757,12 +17117,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkuhine",
+    ],
+    "sortKey": Array [
+      "88",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkuine",
-      "sortKey": "89",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -15782,17 +17144,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Tihvinä",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15802,10 +17166,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "dem.s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15815,19 +17179,23 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "dem.s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "dem.s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
             "Subcategorisation": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                },
                 "_": "dem.",
+                "display": Array [
+                  "no",
+                ],
               },
             ],
           },
@@ -15837,28 +17205,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkuine",
+    ],
+    "sortKey": Array [
+      "89",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkukas",
-      "sortKey": "90",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahku",
-                    },
                     "_": "→ ahku 1.",
+                    "xlink:href": Array [
+                      "ahku",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -15878,17 +17248,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15898,10 +17270,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "poss.a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15911,11 +17283,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "poss.a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "poss.a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -15925,12 +17301,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkukas",
+    ],
+    "sortKey": Array [
+      "90",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkuri",
-      "sortKey": "91",
-    },
     "HeadwordCtn": Array [
       Object {
         "ExampleBlock": Array [
@@ -15947,17 +17325,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Korpis",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -15967,10 +17347,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -15980,11 +17360,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -15994,28 +17378,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkuri",
+    ],
+    "sortKey": Array [
+      "91",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkuutuo",
-      "sortKey": "92",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahku",
-                    },
                     "_": "→ ahku 1.",
+                    "xlink:href": Array [
+                      "ahku",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -16035,17 +17421,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kiestinki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16055,10 +17443,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16068,11 +17456,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -16082,12 +17474,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkuutuo",
+    ],
+    "sortKey": Array [
+      "92",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahkuvuo",
-      "sortKey": "93",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -16107,17 +17501,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16127,10 +17523,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "v.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16140,11 +17536,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "v.",
-                  "value": "verb",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "v.",
+                ],
+                "value": Array [
+                  "verb",
+                ],
               },
             ],
           },
@@ -16154,12 +17554,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahkuvuo",
+    ],
+    "sortKey": Array [
+      "93",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahlei",
-      "sortKey": "94",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -16180,17 +17582,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16200,10 +17604,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16213,11 +17617,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -16227,28 +17635,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahlei",
+    ],
+    "sortKey": Array [
+      "94",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahleiskoi",
-      "sortKey": "95",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahliskoi",
-                    },
                     "_": "→ ahliskoi.",
+                    "xlink:href": Array [
+                      "ahliskoi",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -16256,10 +17666,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16269,22 +17679,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -16294,28 +17712,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahleiskoi",
+    ],
+    "sortKey": Array [
+      "95",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahleittša",
-      "sortKey": "96",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahliskoi",
-                    },
                     "_": "→ ahliskoi.",
+                    "xlink:href": Array [
+                      "ahliskoi",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -16323,10 +17743,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16336,22 +17756,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -16362,28 +17790,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahleittša",
+    ],
+    "sortKey": Array [
+      "96",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahleskoi",
-      "sortKey": "97",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahliskoi",
-                    },
                     "_": "→ ahliskoi.",
+                    "xlink:href": Array [
+                      "ahliskoi",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -16391,10 +17821,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16404,22 +17834,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -16429,12 +17867,14 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahleskoi",
+    ],
+    "sortKey": Array [
+      "97",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahliskoi",
-      "sortKey": "98",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
@@ -16455,17 +17895,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16481,17 +17923,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16508,17 +17952,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kontokki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16535,32 +17981,40 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                     ],
                     "_": "  ()  ()  ()  (). . ",
@@ -16568,17 +18022,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Suoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16595,17 +18051,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Säämäj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16618,11 +18076,13 @@ Array [
                     ],
                     "RangeOfApplication": Array [
                       Object {
-                        "$": Object {
-                          "freeType": "käyttöala",
-                          "kotus:grouping": "8",
-                        },
                         "_": "harv.",
+                        "freeType": Array [
+                          "käyttöala",
+                        ],
+                        "kotus:grouping": Array [
+                          "8",
+                        ],
                       },
                     ],
                     "_": "  englantilainen kangas (). ",
@@ -16630,17 +18090,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vitele",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16650,10 +18112,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16663,22 +18125,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -16688,28 +18158,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahliskoi",
+    ],
+    "sortKey": Array [
+      "98",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahliskoine",
-      "sortKey": "99",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahliskoi",
-                    },
                     "_": "→ ahliskoi.",
+                    "xlink:href": Array [
+                      "ahliskoi",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -16730,17 +18202,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Pistoj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16756,17 +18230,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Uhtua",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16784,17 +18260,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Vuokkin",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16810,17 +18288,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Kontokki",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16836,17 +18316,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Repola",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16862,17 +18344,19 @@ Array [
                 ],
                 "FreeTopic": Array [
                   Object {
-                    "$": Object {
-                      "type": "levikki",
-                    },
                     "GeographicalUsage": Array [
                       Object {
-                        "$": Object {
-                          "class": "pitäjä",
-                          "freeType": "pitäjä",
-                        },
                         "_": "Rukaj",
+                        "class": Array [
+                          "pitäjä",
+                        ],
+                        "freeType": Array [
+                          "pitäjä",
+                        ],
                       },
+                    ],
+                    "type": Array [
+                      "levikki",
                     ],
                   },
                 ],
@@ -16882,10 +18366,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s. ja a.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16895,22 +18379,30 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "a.",
-                  "value": "adjective",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "a.",
+                ],
+                "value": Array [
+                  "adjective",
+                ],
               },
             ],
           },
@@ -16920,28 +18412,30 @@ Array [
         ],
       },
     ],
+    "identifier": Array [
+      "ahliskoine",
+    ],
+    "sortKey": Array [
+      "99",
+    ],
   },
   Object {
-    "$": Object {
-      "identifier": "ahma",
-      "sortKey": "100",
-    },
     "HeadwordCtn": Array [
       Object {
         "Definition": Array [
           Object {
             "SeeAlso": Array [
               Object {
-                "$": Object {
-                  "style": "kanta",
-                },
                 "Ptr": Array [
                   Object {
-                    "$": Object {
-                      "xlink:href": "ahmo",
-                    },
                     "_": "→ ahmo.",
+                    "xlink:href": Array [
+                      "ahmo",
+                    ],
                   },
+                ],
+                "style": Array [
+                  "kanta",
                 ],
               },
             ],
@@ -16949,10 +18443,10 @@ Array [
         ],
         "GrammaticalNote": Array [
           Object {
-            "$": Object {
-              "display": "yes",
-            },
             "_": "s.",
+            "display": Array [
+              "yes",
+            ],
           },
         ],
         "Headword": Array [
@@ -16962,11 +18456,15 @@ Array [
           Object {
             "PartOfSpeech": Array [
               Object {
-                "$": Object {
-                  "display": "no",
-                  "freeValue": "s.",
-                  "value": "noun",
-                },
+                "display": Array [
+                  "no",
+                ],
+                "freeValue": Array [
+                  "s.",
+                ],
+                "value": Array [
+                  "noun",
+                ],
               },
             ],
           },
@@ -16975,6 +18473,12 @@ Array [
           "ahma",
         ],
       },
+    ],
+    "identifier": Array [
+      "ahma",
+    ],
+    "sortKey": Array [
+      "100",
     ],
   },
 ]

--- a/tests/unit/fixtures/entry-fixtures.ts
+++ b/tests/unit/fixtures/entry-fixtures.ts
@@ -15,11 +15,11 @@ export const entryFixture = {
         {
           PartOfSpeech: [
             {
-              $: {
-                display: 'no',
-                freeValue: 'a.',
-                value: 'adjective',
-              },
+
+              display: ['no'],
+              freeValue: ['a.'],
+              value: ['adjective'],
+
             },
           ],
         },
@@ -27,9 +27,8 @@ export const entryFixture = {
       GrammaticalNote: [
         {
           _: 'a.',
-          $: {
-            display: 'yes',
-          },
+          display: ['yes'],
+
         },
       ],
       Definition: [
@@ -97,11 +96,11 @@ export const entryFixtureMultipleMeanings = {
         {
           PartOfSpeech: [
             {
-              $: {
-                display: 'no',
-                freeValue: 'v.',
-                value: 'verb',
-              },
+
+              display: ['no'],
+              freeValue: ['v.'],
+              value: ['verb'],
+
             },
           ],
         },
@@ -109,9 +108,8 @@ export const entryFixtureMultipleMeanings = {
       GrammaticalNote: [
         {
           _: 'v.',
-          $: {
-            display: 'yes',
-          },
+          display: ['yes'],
+
         },
       ],
     },
@@ -217,19 +215,19 @@ export const thirdEntry = {
         {
           PartOfSpeech: [
             {
-              $: {
-                display: 'no',
-                freeValue: 'kaus.v.',
-                value: 'verb',
-              },
+
+              display: ['no'],
+              freeValue: ['kaus.v.'],
+              value: ['verb'],
+
             },
           ],
           Subcategorisation: [
             {
               _: 'kaus.',
-              $: {
-                display: 'no',
-              },
+
+              display: ['no'],
+
             },
           ],
         },
@@ -237,18 +235,18 @@ export const thirdEntry = {
       GrammaticalNote: [
         {
           _: 'kaus.v.',
-          $: {
-            display: 'yes',
-          },
+
+          display: ['yes'],
+
         },
       ],
       Definition: [
         {
           SeeAlso: [
             {
-              $: {
-                style: 'kanta',
-              },
+
+              style: 'kanta',
+
               Ptr: [
                 {
                   _: '→ önkähteäkseh.',
@@ -274,16 +272,16 @@ export const thirdEntry = {
               ],
               FreeTopic: [
                 {
-                  $: {
-                    type: 'levikki',
-                  },
+
+                  type: 'levikki',
+
                   GeographicalUsage: [
                     {
                       _: 'Suoj',
-                      $: {
-                        freeType: 'pitäjä',
-                        class: 'pitäjä',
-                      },
+
+                      freeType: 'pitäjä',
+                      class: 'pitäjä',
+
                     },
                   ],
                 },

--- a/tests/unit/fixtures/example-fixture.ts
+++ b/tests/unit/fixtures/example-fixture.ts
@@ -12,26 +12,9 @@ export const complexExampleFixture = {
     'Lämmitä kyly utuni, Pian pirtti riuottele',
     "Kussakk' on utuni vyöllä Kesä uuhen uujuloista",
   ],
-  RangeOfApplication: [
-    {
-      _: 'run.',
-      $: { freeType: 'käyttöala', 'kotus:grouping': '27' },
-    },
-  ],
-  GeographicalUsage: [
-    {
-      _: '(SKVR I 484a)',
-      $: { freeType: 'lähde', class: 'lähde' },
-      sub: ['1'],
-    },
-    {
-      _: '(SKVR I 1679h)',
-      $: { freeType: 'lähde', class: 'lähde' },
-      sub: ['3'],
-    },
-  ],
 };
 
 export default {
   simpleExampleFixture,
+  complexExampleFixture,
 };

--- a/tests/unit/utils/entry-data-source.test.ts
+++ b/tests/unit/utils/entry-data-source.test.ts
@@ -6,7 +6,81 @@ describe('Utils: entry data soruce', () => {
     const result = getEntryDataSource(entryFixture);
 
     const expected = {
-      Definition: ['kiikkerä.'], ExampleBlock: [{ ExampleCtn: [{ Example: [{ Fragment: ['keilak|ko, -an ~ -on. keilakko veneh'], RangeOfApplication: [{ $: { freeType: 'käyttöala', 'kotus:grouping': '8' }, _: 'harv.' }], _: '  (). ' }], FreeTopic: [{ $: { type: 'levikki' }, GeographicalUsage: [{ $: { class: 'pitäjä', freeType: 'pitäjä' }, _: 'Säämäj' }] }] }] }], GrammaticalNote: [{ $: { display: 'yes' }, _: 'a.' }], Headword: ['keilakko'], PartOfSpeechCtn: [{ PartOfSpeech: [{ $: { display: 'no', freeValue: 'a.', value: 'adjective' } }] }], SearchForm: ['keilakko'],
+      Headword: [
+        'keilakko',
+      ],
+      SearchForm: [
+        'keilakko',
+      ],
+      PartOfSpeechCtn: [
+        {
+          PartOfSpeech: [
+            {
+              display: [
+                'no',
+              ],
+              freeValue: [
+                'a.',
+              ],
+              value: [
+                'adjective',
+              ],
+            },
+          ],
+        },
+      ],
+      GrammaticalNote: [
+        {
+          _: 'a.',
+          display: [
+            'yes',
+          ],
+        },
+      ],
+      Definition: [
+        'kiikkerä.',
+      ],
+      ExampleBlock: [
+        {
+          ExampleCtn: [
+            {
+              Example: [
+                {
+                  _: '  (). ',
+                  Fragment: [
+                    'keilak|ko, -an ~ -on. keilakko veneh',
+                  ],
+                  RangeOfApplication: [
+                    {
+                      _: 'harv.',
+                      $: {
+                        freeType: 'käyttöala',
+                        'kotus:grouping': '8',
+                      },
+                    },
+                  ],
+                },
+              ],
+              FreeTopic: [
+                {
+                  $: {
+                    type: 'levikki',
+                  },
+                  GeographicalUsage: [
+                    {
+                      _: 'Säämäj',
+                      $: {
+                        freeType: 'pitäjä',
+                        class: 'pitäjä',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     };
 
     expect(result).toEqual(expected);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "strictNullChecks": true,
-    "target": "es6", 
+    "target": "es2019", 
     "outDir": "dist",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
Previously wrapped attributes in odd objects which were kinda hard to reason with. Change options to make attributes just keys same as everything else.

This leads to sideeffect of former attribute values being array values now. May be easier to keep this “everything is an array” to avoid always checking for arrays.

Update test fixtures to match the slightly changed output.